### PR TITLE
Remove $ from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Examples`](https://rpearce.github.io/image-zoom/) for more).
 
 ## Installation
 ```bash
-$ npm i react-medium-image-zoom
+npm i react-medium-image-zoom
 ```
 or
 ```bash
-$ yarn add react-medium-image-zoom
+yarn add react-medium-image-zoom
 ```
 or
 ```html


### PR DESCRIPTION
Quick change. Since GitHub allows copy from snippets directly, it was copying the $ too which does not work when pasted into a terminal.