### PR TITLE
Add getScale property

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ You can pass these options to either the default or controlled components.
 | `wrapStyle` | `Object` | no | `null` | Optional style object to pass to the wrapper element. Useful when you want the `<Zoom>` container to be `width: '100%'`, for example |
 | `zoomMargin` | `Number` | no | `0` | Offset in pixels the zoomed image should be from the `window`' boundaries |
 | `zoomZindex` | `Number` | no | `2147483647` | `z-index` value for the zoom overlay |
+| `getScale` | `Function` | no | `null` | `Function that returns the amount of zoom` |
 
 ## Only the controlled component
 You can pass these options to only the controlled component.

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -12,6 +12,7 @@ import React, {
   useState
 } from 'react'
 import ControlledActivated from './ControlledActivated'
+import { GetScaleFn } from './helpers'
 import './styles.css'
 
 interface Props {
@@ -29,6 +30,7 @@ interface Props {
   wrapStyle?: CSSProperties
   zoomMargin?: number
   zoomZindex?: number
+  getScale?: GetScaleFn
 }
 
 const Controlled: FC<Props> = ({
@@ -45,7 +47,8 @@ const Controlled: FC<Props> = ({
   wrapElement: WrapElement = 'div',
   wrapStyle,
   zoomMargin = 0,
-  zoomZindex = 2147483647
+  zoomZindex = 2147483647,
+  getScale
 }: Props) => {
   const [isChildLoaded, setIsChildLoaded] = useState<boolean>(false)
   const wrapRef = useRef<HTMLElement>(null)
@@ -105,6 +108,7 @@ const Controlled: FC<Props> = ({
             transitionDuration={transitionDuration}
             zoomMargin={zoomMargin}
             zoomZindex={zoomZindex}
+            getScale={getScale}
           >
             {children}
           </ControlledActivated>

--- a/source/ControlledActivated.tsx
+++ b/source/ControlledActivated.tsx
@@ -15,6 +15,7 @@ import useWindowSize from 'react-use/lib/useWindowSize'
 import {
   getModalContentStyle,
   getModalOverlayStyle,
+  GetScaleFn,
   pseudoParentEl
 } from './helpers'
 import './styles.css'
@@ -34,6 +35,7 @@ interface Props {
   transitionDuration?: number
   zoomMargin?: number
   zoomZindex?: number
+  getScale?: GetScaleFn
 }
 
 const ControlledActivated: FC<Props> = ({
@@ -50,7 +52,8 @@ const ControlledActivated: FC<Props> = ({
   scrollableEl = window,
   transitionDuration = 300,
   zoomMargin = 0,
-  zoomZindex = 2147483647
+  zoomZindex = 2147483647,
+  getScale
 }: Props) => {
   const btnRef = useRef<HTMLButtonElement>(null)
   const [, forceUpdate] = useState<number>(0)
@@ -176,7 +179,8 @@ const ControlledActivated: FC<Props> = ({
     top,
     transitionDuration,
     width,
-    zoomMargin
+    zoomMargin,
+    getScale
   })
 
   return isActive

--- a/source/Uncontrolled.tsx
+++ b/source/Uncontrolled.tsx
@@ -11,6 +11,7 @@ import React, {
   useRef,
   useState
 } from 'react'
+import { GetScaleFn } from './helpers'
 import './styles.css'
 import UncontrolledActivated from './UncontrolledActivated'
 
@@ -27,6 +28,7 @@ interface Props {
   wrapStyle?: CSSProperties
   zoomMargin?: number
   zoomZindex?: number
+  getScale?: GetScaleFn
 }
 
 const Uncontrolled: FC<Props> = ({
@@ -41,7 +43,8 @@ const Uncontrolled: FC<Props> = ({
   wrapElement: WrapElement = 'div',
   wrapStyle,
   zoomMargin = 0,
-  zoomZindex = 2147483647
+  zoomZindex = 2147483647,
+  getScale
 }: Props) => {
   const [isActive, setIsActive] = useState<boolean>(false)
   const [isChildLoaded, setIsChildLoaded] = useState<boolean>(false)
@@ -101,6 +104,7 @@ const Uncontrolled: FC<Props> = ({
             transitionDuration={transitionDuration}
             zoomMargin={zoomMargin}
             zoomZindex={zoomZindex}
+            getScale={getScale}
           >
             {children}
           </UncontrolledActivated>

--- a/source/UncontrolledActivated.tsx
+++ b/source/UncontrolledActivated.tsx
@@ -14,6 +14,7 @@ import useWindowSize from 'react-use/lib/useWindowSize'
 import {
   getModalContentStyle,
   getModalOverlayStyle,
+  GetScaleFn,
   pseudoParentEl
 } from './helpers'
 import './styles.css'
@@ -31,6 +32,7 @@ interface Props {
   transitionDuration?: number
   zoomMargin?: number
   zoomZindex?: number
+  getScale?: GetScaleFn
 }
 
 const UncontrolledActivated: FC<Props> = ({
@@ -45,7 +47,8 @@ const UncontrolledActivated: FC<Props> = ({
   scrollableEl = window,
   transitionDuration = 300,
   zoomMargin = 0,
-  zoomZindex = 2147483647
+  zoomZindex = 2147483647,
+  getScale
 }: Props) => {
   const btnRef = useRef<HTMLButtonElement>(null)
   const [, forceUpdate] = useState<number>(0)
@@ -130,7 +133,8 @@ const UncontrolledActivated: FC<Props> = ({
     top,
     transitionDuration,
     width,
-    zoomMargin
+    zoomMargin,
+    getScale
   })
 
   return createPortal(

--- a/source/helpers.ts
+++ b/source/helpers.ts
@@ -1,6 +1,6 @@
 const toDurationString = (duration: number): string => `${duration}ms`
 
-interface GetScale {
+export interface GetScales {
   height: number
   innerHeight: number
   innerWidth: number
@@ -8,18 +8,26 @@ interface GetScale {
   zoomMargin: number
 }
 
-export const getScale = ({
+export interface GetScalesResult {
+  scaleX: number
+  scaleY: number
+  scale: number
+}
+
+export type GetScaleFn = (props: GetScales & GetScalesResult) => number
+
+export const getScales = ({
   height,
   innerHeight,
   innerWidth,
   width,
   zoomMargin
-}: GetScale): number => {
+}: GetScales): GetScalesResult => {
   const scaleX = innerWidth / (width + zoomMargin)
   const scaleY = innerHeight / (height + zoomMargin)
   const scale = Math.min(scaleX, scaleY)
 
-  return scale
+  return { scaleX, scaleY, scale }
 }
 
 interface GetModalContentStyle {
@@ -34,6 +42,7 @@ interface GetModalContentStyle {
   transitionDuration: number
   width: number
   zoomMargin: number
+  getScale?: GetScaleFn
 }
 
 type GetModalContentStyleReturnType = {
@@ -57,7 +66,8 @@ export const getModalContentStyle = ({
   top,
   transitionDuration,
   width,
-  zoomMargin
+  zoomMargin,
+  getScale
 }: GetModalContentStyle): GetModalContentStyleReturnType => {
   const transitionDurationString = toDurationString(transitionDuration)
 
@@ -80,13 +90,15 @@ export const getModalContentStyle = ({
   }
 
   // Get amount to scale item
-  const scale = getScale({
+  const scalesArgs = {
     height,
     innerWidth,
     innerHeight,
     width,
     zoomMargin
-  })
+  }
+  const scales = getScales(scalesArgs)
+  const scale = getScale ? getScale({ ...scalesArgs, ...scales }) : scales.scale
 
   // Get the the coords for center of the viewport
   const viewportX = innerWidth / 2

--- a/source/styles.css
+++ b/source/styles.css
@@ -16,6 +16,8 @@
   width: 100%;
   height: 100%;
   transition-property: background-color;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 [data-rmiz-btn-open],
 [data-rmiz-btn-close] {

--- a/stories.js
+++ b/stories.js
@@ -621,3 +621,47 @@ stories.add('larger image size', () => (
     </ImgStory>
   </div>
 ))
+
+stories.add('max width zoom', () => (
+  <ImgStory title="Max width zoom">
+    <Zoom
+      closeText={text('Unzoom label', 'Unzoom image')}
+      openText={text('Zoom label', 'Zoom image')}
+      overlayBgColorEnd={color(
+        'Overlay bgColor end',
+        'rgba(255, 255, 255, 0.95)'
+      )}
+      overlayBgColorStart={color(
+        'Overlay bgColor start',
+        'rgba(255, 255, 255, 0)'
+      )}
+      transitionDuration={number('Transition duration', 300, {
+        min: 0,
+        max: 5000,
+        range: true,
+        step: 100
+      })}
+      wrapElement={text('Wrapper element', 'div')}
+      zoomMargin={number('Zoom margin', 0, {
+        min: 0,
+        max: 500,
+        range: true,
+        step: 50
+      })}
+      zoomZindex={number('Zoom z-index', 2147483647, {
+        min: 0,
+        max: 2147483647,
+        range: true,
+        step: 1
+      })}
+      getScale={({ scaleX }) => scaleX}
+    >
+      <img
+        alt={imgThatWanakaTree.alt}
+        src={imgThatWanakaTree.src}
+        style={{ height: '100%', maxWidth: '100%' }}
+        width="500"
+      />
+    </Zoom>
+  </ImgStory>
+))


### PR DESCRIPTION
## Pre-Flight Checklist
I have made sure to
- [x] add tests to maintain 100% test coverage & add a Storybook example (when
    this makes sense)
- [x] manually test all the Storybook examples
- [ ] run `$ yarn build` to build the project code

Hi, I was wondering how to enlarge the zoom scale at some of the images. On our team blog some images have 2x more height than width and the magnification is too small to read text on them. I decided to create a programmable possibility to specify zoom scale based on some image properties. Take a look at the code and example from a storybook. Greetings!