### PR TITLE
fix: replace deprecated ReactType types with ElementType

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -3,7 +3,7 @@ import React, {
   CSSProperties,
   FC,
   ReactNode,
-  ReactType,
+  ElementType,
   RefObject,
   StrictMode,
   memo,
@@ -25,7 +25,7 @@ export interface ControlledProps {
   portalEl?: HTMLElement
   scrollableEl?: HTMLElement | Window
   transitionDuration?: number
-  wrapElement?: ReactType
+  wrapElement?: ElementType
   wrapStyle?: CSSProperties
   zoomMargin?: number
   zoomZindex?: number

--- a/source/Uncontrolled.tsx
+++ b/source/Uncontrolled.tsx
@@ -3,7 +3,7 @@ import React, {
   CSSProperties,
   FC,
   ReactNode,
-  ReactType,
+  ElementType,
   RefObject,
   StrictMode,
   memo,
@@ -23,7 +23,7 @@ export interface UncontrolledProps {
   portalEl?: HTMLElement
   scrollableEl?: HTMLElement | Window
   transitionDuration?: number
-  wrapElement?: ReactType
+  wrapElement?: ElementType
   wrapStyle?: CSSProperties
   zoomMargin?: number
   zoomZindex?: number


### PR DESCRIPTION
This pull request closes #302

## Pre-Flight Checklist

I have made sure to:

- [ ] add tests & add a Storybook example (when this makes sense)
- [ ] manually test all the Storybook examples
